### PR TITLE
New features

### DIFF
--- a/src/EnquiryPage.php
+++ b/src/EnquiryPage.php
@@ -167,7 +167,7 @@ class EnquiryPage extends Page
                     ])
                 );
             } elseif (
-                !in_array($el->FieldType, ['Header', 'Note']) &&
+                !in_array($el->FieldType, ['Header', 'Note', 'HTML']) &&
                 isset($data[$key]) && $data[$key] != ''
             ) {
                 $hdr = htmlspecialchars($el->FieldName);

--- a/src/EnquiryPage.php
+++ b/src/EnquiryPage.php
@@ -50,6 +50,7 @@ class EnquiryPage extends Page
         'EmailSubject' => 'Varchar(254)',
         'EmailSubmitButtonText' => 'Varchar(50)',
         'EmailSubmitCompletion' => 'HTMLText',
+        'EmailPlain' => 'Boolean',
         'AddCaptcha' => 'Boolean',
         'CaptchaText' => 'Varchar(50)',
         'CaptchaHelp' => 'Varchar(100)',
@@ -63,6 +64,7 @@ class EnquiryPage extends Page
         'EmailSubject' => 'Website Enquiry',
         'EmailSubmitButtonText' => 'Submit Enquiry',
         'EmailSubmitCompletion' => "<p>Thanks, we've received your enquiry and will respond as soon as we're able.</p>",
+        'EmailPlain' => false,
         'CaptchaText' => 'Verification Image'
     ];
 
@@ -97,6 +99,10 @@ class EnquiryPage extends Page
             EmailField::create('EmailBcc', 'BCC Copy (optional)')
                 ->setRightTitle('If you would like a copy of the enquiry to be sent elsewhere'),
             TextField::create('EmailSubmitButtonText', 'Submit Button Text'),
+            DropdownField::create('EmailPlain', 'Email format', [
+                    0 => 'HTML email (default)',
+                    1 => 'Plain text email'
+            ]),
             HeaderField::create('CaptchaHdr', 'Form Captcha'),
             DropdownField::create('AddCaptcha', 'Captcha Image', [
                     1 => 'Yes add a captcha image',

--- a/src/EnquiryPageController.php
+++ b/src/EnquiryPageController.php
@@ -205,11 +205,16 @@ class EnquiryPageController extends PageController
         //abuse / tracking
         $email->getSwiftMessage()->getHeaders()->addTextHeader('X-Sender-IP', $_SERVER['REMOTE_ADDR']);
 
-        $email->setHTMLTemplate('Email/EnquiryFormEmail');
         $templateData = $this->getTemplateData($data);
         $email->setData($templateData);
 
-        $email->send();
+        if ($this->EmailPlain) {
+            $email->setPlainTemplate('Email/EnquiryFormEmail');
+            $email->sendPlain();
+        } else {
+            $email->setHTMLTemplate('Email/EnquiryFormEmail');
+            $email->send();
+        }
 
         if (Director::is_ajax()) {
             return $this->renderWith('Layout/EnquiryPageAjaxSuccess');

--- a/src/EnquiryPageController.php
+++ b/src/EnquiryPageController.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\EmailField;
@@ -91,7 +92,9 @@ class EnquiryPageController extends PageController
                 }
             } elseif ($el->FieldType == 'Checkbox') {
                 $options = preg_split('/\n\r?/', $el->FieldOptions, -1, PREG_SPLIT_NO_EMPTY);
-                if (count($options) > 0) {
+                if (count($options) == 1) {
+                    $field = CheckboxField::create($key, trim(reset($options)));
+                } elseif (count($options) > 0) {
                     $tmp = [];
                     foreach ($options as $o) {
                         $tmp[trim($o)] = trim($o);

--- a/src/EnquiryPageController.php
+++ b/src/EnquiryPageController.php
@@ -120,6 +120,8 @@ class EnquiryPageController extends PageController
                 } else {
                     $field = HeaderField::create($key, $el->FieldName, 4);
                 }
+            } elseif ($el->FieldType == 'HTML') {
+                $field = LiteralField::create($key, $el->FieldOptions);
             } elseif ($el->FieldType == 'Note') {
                 if ($el->FieldOptions) {
                     $field = LiteralField::create($key, '<p class="note">'.nl2br(htmlspecialchars($el->FieldOptions)).'</p>');

--- a/src/Model/EnquiryFormField.php
+++ b/src/Model/EnquiryFormField.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\HeaderField;
+use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
@@ -24,8 +25,8 @@ class EnquiryFormField extends DataObject
     private static $db = [
         'SortOrder' => 'Int',
         'FieldName' => 'Varchar(150)',
-        'FieldType' => 'Enum("Text, Email, Select, Checkbox, Radio, Header, Note","Text")',
-        'FieldOptions' => 'Text',
+        'FieldType' => 'Enum("Text, Email, Select, Checkbox, Radio, Header, Note, HTML","Text")',
+        'FieldOptions' => 'HTMLText',
         'PlaceholderText' => 'Varchar(150)',
         'RequiredField' => 'Boolean',
     ];
@@ -37,7 +38,8 @@ class EnquiryFormField extends DataObject
         'Checkbox' => 'Checkbox - multiple tick boxes',
         'Radio' => 'Radio - single tick option',
         'Header' => 'Header in the form',
-        'Note' => 'Note in form'
+        'Note' => 'Note in form',
+        'HTML' => 'Arbitrary HTML'
     ];
 
     private static $has_one = [
@@ -101,6 +103,15 @@ class EnquiryFormField extends DataObject
                 ]);
                 $fields->removeByName('PlaceholderText');
                 break;
+            case 'HTML':
+                $fields->removeByName('RequiredField');
+                $fields->removeByName('FieldOptions');
+                $fields->addFieldsToTab('Root.Main', [
+                    HeaderField::create('FieldOptionsInfo', 'The following chunk of HTML will be inserted inside the form', 4),
+                    HtmlEditorField::create('FieldOptions', 'HTML')
+                ]);
+                $fields->removeByName('PlaceholderText');
+                break;
             case 'Text':
                 $fields->removeByName('FieldOptions');
                 $rows = NumericField::create('FieldOptions', 'Number of rows');
@@ -125,7 +136,7 @@ class EnquiryFormField extends DataObject
 
     public function getRequired()
     {
-        if (in_array($this->FieldType, ['Header', 'Note'])) {
+        if (in_array($this->FieldType, ['Header', 'Note', 'HTML'])) {
             return false;
         }
         return $this->RequiredField ? 'Yes' : 'No';

--- a/src/Model/EnquiryFormField.php
+++ b/src/Model/EnquiryFormField.php
@@ -77,7 +77,6 @@ class EnquiryFormField extends DataObject
                 break;
             case 'Checkbox':
                 $fields->addFieldToTab('Root.Main', HeaderField::create('FieldHdr_' . $hdrcnt++, 'Add checkbox options below (one per line) - users can select multiple:', 4), 'FieldOptions');
-                $fields->removeByName('RequiredField');
                 $fields->removeByName('PlaceholderText');
                 break;
             case 'Radio':
@@ -156,7 +155,7 @@ class EnquiryFormField extends DataObject
         $this->FieldName = trim($this->FieldName);
         if ($this->FieldType == 'Radio') {
             $this->PlaceholderText = '';
-        } elseif (!in_array($this->FieldType, ['Text', 'Email', 'Select'])) {
+        } elseif (!in_array($this->FieldType, ['Text', 'Email', 'Select', 'Checkbox'])) {
             $this->RequiredField = 0;
             $this->PlaceholderText = '';
         }

--- a/templates/Email/EnquiryFormEmail.ss
+++ b/templates/Email/EnquiryFormEmail.ss
@@ -1,20 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
-<body>
-<table cellpadding="5" style="font-family:Arial,helvetica">
-<% loop $EmailData %>
-	<% if $Type = Header %>
-	<tr>
-		<td valign="top" colspan="2" style="padding-top:10px; font-size:120%">
-			<u><b>$Header</b></u>
-		</td>
-	</tr>
-	<% else %>
-	<tr>
-		<td valign="top"><b>$Header</b></td>
-		<td valign="top">$Value</td>
-	</tr>
-	<% end_if %>
-<% end_loop %>
-</table>
-</body>
+  <body>
+    <table cellpadding="5" style="font-family:Arial,helvetica">
+      <% loop $EmailData %>
+        <tr>
+          <% if $Type == 'Header' %>
+            <td valign="top" colspan="2" style="padding-top:10px; font-size:120%">
+              <u><b>$Header.XML</b></u>
+            </td>
+          <% else %>
+            <td valign="top"><b>$Header.XML</b></td>
+            <td valign="top">
+              <% if $Value.count %><%-- This is an array --%>
+                <ul>
+                  <% loop $Value %><li>$Item.XML</li><% end_loop %>
+                </ul>
+              <% else_if $Value.FirstParagraph %><%-- This is a text block --%>
+                <pre>$Value.XML</pre>
+              <% else %><%-- This is a string --%>
+                $Value.XML
+              <% end_if %>
+            </td>
+          <% end_if %>
+        </tr>
+      <% end_loop %>
+    </table>
+  </body>
 </html>


### PR DESCRIPTION
Hi Ralph,

these are my additions to be able to use this module on my [contact page](http://www.entidi.com/contact/). Not sure if you want to cherry-pick, merge the whole branch or not even bother, so I opened this PR to al least let you know what I'm doing.

I basically need 3 things missing from silverstripe-enquiry-page:
1. **a required checkbox**
   This is provided by 66751a7 in a quite straightforward way: do not hide the _Required_ flag on checkboxes and if the set is only 1 element use `CheckboxField` instead of `CheckboxSetField`.
2. **custom HTML injection**
   Provided by 5ab7b81, I had to change `FieldOptions` to `HTMLText` because of [this check](https://github.com/silverstripe/silverstripe-framework/blob/4.0.1/src/Forms/HTMLEditor/HTMLEditorField.php#L142). This is not a big problem because at the end an `HTMLText` is also a `Text` but AFAIK it introduces a slight backward incompatibility: using it in templates without explicit casting (e.g. `$FieldOptions` instead of `$FieldOptions.{RAW or XML}`) changes its escaping (`HTMLText` uses RAW while `Text` uses XML).
3. **plain text email notification**
   This is the most invasive change. First of all I had to move all escaping into the templates (ed86f04). After that, adding plain text support was quite easy (7219278).

I need all 3 features so I'll keep my repository around but I'd be more than happy to upstream whatever possible.
  