### PR TITLE
Allow to customise the client IP retrieval method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Axllent\EnquiryPage\EnquiryPage:
 
 Please note that the height should be no less than 20 (else the numbers may not be displayed properly).
 
+If you use web services that dynamically change the `REMOTE_ADDR` field (most notably
+CloudFlare) you can configure another field, e.g.:
+
+```
+Axllent\EnquiryPage\EnquiryPage:
+  # Try $_SERVER['HTTP_CF_CONNECTING_IP'] (CloudFlare custom field) before
+  # $_SERVER['REMOTE_ADDR'], so it will work with and without CloudFlare
+  client_ip_fields:
+    - HTTP_CF_CONNECTING_IP
+    - REMOTE_ADDR
+```
+
+If required, you can disable the client IP retrieval entirely by unsetting that option.
+
 
 ## JavaScript validation
 

--- a/src/EnquiryPage.php
+++ b/src/EnquiryPage.php
@@ -4,6 +4,7 @@ namespace Axllent\EnquiryPage;
 
 use Axllent\EnquiryPage\Model\EnquiryFormField;
 use Page;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\GridField\GridField;
@@ -36,6 +37,8 @@ class EnquiryPage extends Page
     private static $captcha_img_height = 30; // default verification image height
 
     private static $js_validation = false; // add JavaScript field validation
+
+    private static $client_ip_fields = 'REMOTE_ADDR'; // Looked up in $_SERVER
 
     private static $random_string = '3HNbhqWBEg'; // random string
 
@@ -71,6 +74,38 @@ class EnquiryPage extends Page
     protected $usedFields = [];
 
     protected $usedFieldCounter = 0;
+
+    /*
+     * Get the client IP by querying the $_SERVER array.
+     * @return string
+     */
+    public static function get_client_ip()
+    {
+        $fields = Config::inst()->get(self::class, 'client_ip_fields');
+        if ($fields) {
+            if (is_string($fields)) {
+                $fields = [ $fields ];
+            }
+            foreach ($fields as $field) {
+                if (isset($_SERVER[$field])) {
+                    return $_SERVER[$field];
+                }
+            }
+        }
+        return '';
+    }
+
+    /*
+     * Return the hash to use for comparison.
+     * @param string $token
+     * @return string
+     */
+    public static function get_hash($token)
+    {
+        $ip = self::get_client_ip();
+        $random_string = Config::inst()->get(self::class, 'random_string');
+        return md5(trim($token) . $ip. $random_string);
+    }
 
     public function getCMSFields()
     {

--- a/src/EnquiryPageController.php
+++ b/src/EnquiryPageController.php
@@ -193,7 +193,10 @@ class EnquiryPageController extends PageController
         }
 
         //abuse / tracking
-        $email->getSwiftMessage()->getHeaders()->addTextHeader('X-Sender-IP', $_SERVER['REMOTE_ADDR']);
+        $ip = EnquiryPage::get_client_ip();
+        if ($ip) {
+            $email->getSwiftMessage()->getHeaders()->addTextHeader('X-Sender-IP', $ip);
+        }
 
         $templateData = $this->getTemplateData($data);
         $email->setData($templateData);
@@ -239,14 +242,14 @@ class EnquiryPageController extends PageController
             imagesetpixel($my_image, $x, $y, $random_colours[array_rand($random_colours)]);
         }
         $x = rand(1, 15);
-        $rand_string = rand(1000, 9999);
-        $numbers = str_split($rand_string);
+        $token = rand(1000, 9999);
+        $numbers = str_split($token);
         foreach ($numbers as $number) {
             $y = rand(1, $height - 20);
             imagestring($my_image, 5, $x, $y, $number, 0x000000);
             $x = $x+12;
         }
-        $request->getSession()->set('customcaptcha', md5($rand_string.$_SERVER['REMOTE_ADDR']) . Config::inst()->get('Axllent\EnquiryPage\EnquiryPage', 'random_string'));
+        $request->getSession()->set('customcaptcha', EnquiryPage::get_hash($token));
         $this->response->setBody(imagejpeg($my_image));
         imagedestroy($my_image);
         return $this->response;

--- a/src/Forms/CaptchaField.php
+++ b/src/Forms/CaptchaField.php
@@ -2,9 +2,9 @@
 
 namespace Axllent\EnquiryPage\Forms;
 
+use \Axllent\EnquiryPage\EnquiryPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Session;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\TextField;
 
 class CaptchaField extends TextField
@@ -36,13 +36,13 @@ class CaptchaField extends TextField
      */
     public function validate($validator)
     {
-        $this->value = trim($this->value);
-        $request = Controller::curr()->getRequest();
-        $session_captcha = $request->getSession()->get('customcaptcha');
+        $typed = EnquiryPage::get_hash($this->value);
+        $generated = Controller::curr()
+            ->getRequest()
+            ->getSession()
+            ->get('customcaptcha');
 
-        if (md5(trim($this->value) . $_SERVER['REMOTE_ADDR']) .
-            Config::inst()->get('Axllent\EnquiryPage\EnquiryPage', 'random_string') != $session_captcha
-        ) {
+        if ($typed != $generated) {
             $validator->validationError(
                 $this->name,
                 'Codes do not match, please try again',


### PR DESCRIPTION
In some circumstances, retrieving the client IP from `REMOTE_ADDR` is
wrong. Some web services, e.g. CloudFlare, change that value on every
hit. This means that in the token generation phase and after submitting
the form I have two different IPs, hence the hash comparison always
fails.

Now the field to use can be changed in YAML, defaulting to
`REMOTE_ADDR` so backward compatibility is retained.